### PR TITLE
Add pkg-config lookup for xml2 headers

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+0.6.4 - 2015-04-09
+  - use pkg-config to lookup libxml2 header location
+
 0.6.3 - 2014-02-20
   - clean up, restore Ruby 1.8.7 compatibility in tests
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -39,7 +39,12 @@ startup; that allows setting up a custom transform.
     aug.get("/files/etc/aliases/*[name = 'postmaster']/value")
   end
 
-      
+
+== Build Dependencies
+
+To build or install this gem manually, headers for libaugeas and libxml are
+needed. Additionally the pkg-config tool has to be installed.
+
 == Deprecation Warning
 
 The Augeas API has been heavily rewritten in order to better support

--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ require 'rake/testtask'
 require 'rubygems/package_task'
 
 GEM_NAME = 'augeas'
-GEM_VERSION = '0.6.3'
+GEM_VERSION = '0.6.4'
 EXT_CONF = 'ext/augeas/extconf.rb'
 MAKEFILE = 'ext/augeas/Makefile'
 AUGEAS_MODULE = 'ext/augeas/_augeas.so'

--- a/ext/augeas/extconf.rb
+++ b/ext/augeas/extconf.rb
@@ -43,4 +43,6 @@ unless have_library("xml2")
   raise "libxml2 is not installed"
 end
 
+pkg_config('libxml-2.0')
+
 create_makefile(extension_name)


### PR DESCRIPTION
This allows the gem to be built and installed on Ubuntu 14.04 and probably a
few other distributions.